### PR TITLE
fix: image loading causing layout shift by fixing height dimensions

### DIFF
--- a/src/app/components/navbar.tsx
+++ b/src/app/components/navbar.tsx
@@ -57,7 +57,7 @@ export default function Navbar() {
         setVisible(true);
       }
     }
-  }, [direction, lastY]);
+  }, [direction, lastY, setVisible]);
 
   const themeToggleIcon = useThemeValue(<MoonIcon />, <SunIcon />);
   const toggleTheme = useToggleTheme();

--- a/src/app/sections/projects/cards/index.tsx
+++ b/src/app/sections/projects/cards/index.tsx
@@ -232,7 +232,9 @@ export function ProjectCards({
                       src={project.image}
                       alt={project.name}
                       iconClassName="size-12"
-                      className="w-full h-full max-h-60 rounded-lg object-contain object-top"
+                      className="w-full h-full max-h-60 rounded-lg object-cover object-center"
+                      containerClassName="max-h-60"
+                      loadingClassName="h-60"
                     />
                   </motion.div>
                 )}

--- a/src/app/sections/projects/cards/modal.tsx
+++ b/src/app/sections/projects/cards/modal.tsx
@@ -77,7 +77,9 @@ export default function CardModal({
                   <ImageWithLoading
                     src={active.image}
                     alt={active.name}
-                    className="w-full h-full sm:rounded-tr-lg sm:rounded-tl-lg object-cover object-center"
+                    className="w-full h-full max-h-[40vh] sm:rounded-tr-lg sm:rounded-tl-lg object-cover object-center"
+                    containerClassName="max-h-[40vh]"
+                    loadingClassName="h-[40vh]"
                   />
                 </motion.div>
               )}

--- a/src/components/ui/loading-image.tsx
+++ b/src/components/ui/loading-image.tsx
@@ -8,6 +8,7 @@ export type ImageWithLoadingProps = {
   alt: string;
   className?: string;
   containerClassName?: string;
+  loadingClassName?: string;
   iconClassName?: string;
 };
 
@@ -16,18 +17,20 @@ export default function ImageWithLoading({
   alt,
   className,
   containerClassName,
+  loadingClassName,
   iconClassName,
 }: ImageWithLoadingProps) {
   const [loading, setLoading] = useState(true);
 
   return (
-    <div className={cn("w-full relative", containerClassName)}>
+    <div
+      className={cn(
+        "w-full relative",
+        containerClassName,
+        loading && loadingClassName,
+      )}>
       {loading && (
-        <div
-          className={cn(
-            "absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2",
-            containerClassName,
-          )}>
+        <div className="absolute h-full w-full flex justify-center items-center">
           <LoaderCircleIcon
             className={cn("animate-spin size-24", iconClassName)}
           />


### PR DESCRIPTION
## Resolves AMM-93
### Problem
- The images on project cards were causing massive layout shift because the container didn't have any height while loading the image

### Fix
- Gave the image container fixed height when loading and the container a maximum height the same as the parent